### PR TITLE
include font installation note for Win10

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This is a plugin that automatically adds fingering diagram/chart for different m
 to enable the plugin. Tick the box against 'fingeringdiagram' and apply with 'OK'.
 
 * This plugin relies on **Fiati** font being installed, which can be downloaded here: https://github.com/eduardomourar/fiati/releases
+For windows 10 users: Make sure to install the font for "All Users" or MuseScore (and thus this plugin) won't have access to it.
 
 ### Known issues
 


### PR DESCRIPTION
Due to a Windows10/Qt restriction, MuseScore is unable to see/use user installed fonts. See https://musescore.org/en/node/305374 for context